### PR TITLE
Update base image to debian stable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,24 @@
-FROM debian:stretch
+FROM debian:buster
 
-ARG BUILD_TOOLS="autoconf=2.69-10 \
-  automake=1:1.15-6 \
-  bzip2=1.0.6-8.1 \
-  curl=7.52.1-5+deb9u10 \
-  default-libmysqlclient-dev=1.0.2 \
-  git=1:2.11.0-3+deb9u7 \
-  gnupg=2.1.18-8~deb9u4 \
-  libffi-dev=3.2.1-6 \
-  libreadline-dev=7.0-3 \
-  libssl-dev=1.1.0l-1~deb9u1 \
-  libtool=2.4.6-2 \
-  libxml2-dev=2.9.4+dfsg1-2.2+deb9u2 \
-  libyaml-dev=0.1.7-2 \
-  make=4.1-9.1 \
-  unixodbc-dev=2.3.4-1 \
-  unzip=6.0-21+deb9u2 \
-  zlib1g-dev=1:1.2.8.dfsg-5"
+ARG BUILD_TOOLS="\
+  autoconf=2.69-11 \
+  automake=1:1.16.1-4 \
+  bzip2=1.0.6-9.2~deb10u1 \
+  curl=7.64.0-4+deb10u1 \
+  default-libmysqlclient-dev=1.0.5 \
+  git=1:2.20.1-2+deb10u3 \
+  gnupg=2.2.12-1+deb10u1 \
+  libffi-dev=3.2.1-9 \
+  libreadline-dev=7.0-5 \
+  libssl-dev=1.1.1d-0+deb10u3 \
+  libtool=2.4.6-9 \
+  libxml2-dev=2.9.4+dfsg1-7+b3 \
+  libyaml-dev=0.2.1-1 \
+  make=4.2.1-1.2 \
+  unixodbc-dev=2.3.6-0.1 \
+  unzip=6.0-23+deb10u1 \
+  zlib1g-dev=1:1.2.11.dfsg-1 \
+  "
 
 RUN apt update \
   && apt install -y $BUILD_TOOLS \


### PR DESCRIPTION
Use the current, stable Debian release (buster) for the base image