### PR TITLE
Changed bundler version to a version compatible with Rails 5.2.1 and …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,8 @@ RUN asdf plugin add ruby \
 COPY --chown=app .tool-versions /home/app/
 RUN asdf install
 
-ENV BUNDLER_VERSION=2.1.4
+# Set bundler version for the initial build
+ENV BUNDLER_VERSION=1.16.4
 RUN gem install bundler --version $BUNDLER_VERSION
 RUN bundle config --global path $BUNDLE_PATH
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -283,4 +283,4 @@ RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   2.1.4
+   1.16.4

--- a/bin/console
+++ b/bin/console
@@ -1,3 +1,3 @@
 #!/usr/bin/env sh
 
-docker-compose run --rm web bash -lc "bin/rails console"
+docker-compose run --rm web bash -lc "bin/update && bin/rails console"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,7 +16,7 @@ services:
   web:
     tty: true
     build: .
-    command: bash -lc "bin/rails server"
+    command: bash -lc "(bundle check || bundle install) && bin/rails server"
     links:
       - db
     ports:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -25,3 +25,5 @@ services:
       - source: .
         target: /home/app/src
         type: bind
+    environment:
+      - BUNDLER_VERSION=1.16.4 # Set bundler version for restarts


### PR DESCRIPTION
## Problem

If an interviewee modifies the Gemfile in Power's starter project the interview project crashes and the [Power recommended binstubs](https://github.com/powerhome/power-web-development-interview#working-with-rails-and-docker-compose) stop working. It appears that the bundler versions were updated over the years without testing. 

## Issues

### Modifying the Gemfile results in a broken Rails environment

As an Interviewee if you add a new gem to the Gemfile, Power's starter project fails and the [suggested Rails related binstubs](https://github.com/powerhome/power-web-development-interview#working-with-rails-and-docker-compose) fail. Commands like start, stop, rails, console, bundle, rspec, rake, deps, setup, spring, and update don't work. 

Exceptions are in the flavour of:
```
> bin/bootstrap
== Installing dependencies ==
Bundler can't satisfy your Gemfile's dependencies.
Install missing gems with `bundle install`.
Fetching gem metadata from https://rubygems.org/............
Fetching gem metadata from https://rubygems.org/.
Resolving dependencies...
Bundler could not find compatible versions for gem "bundler":
  In Gemfile:
    bundler-audit was resolved to 0.6.0, which depends on
      bundler (~> 1.2)

    rails (~> 5.2.1) was resolved to 5.2.1, which depends on
      bundler (>= 1.3.0)

  Current Bundler version:
    bundler (2.1.4)
This Gemfile requires a different version of Bundler.
Perhaps you need to update Bundler by running `gem install bundler`?

Could not find gem 'bundler (~> 1.2)', which is required by gem 'rails (~> 5.2.1)', in any of the sources.

== Command ["bundle check || bundle install"] failed ==
```
Note warning: **Bundler could not find compatible versions**

### A silent warning during the docker build

As an Interviewee when you run Power's starter project `bin/bootstrap`, bundler silently warns of a version incompatibility but continues with creating the container. 

```
> bin/bootstrap
...
Step 19/19 : RUN bundle install
 ---> Running in bdfd9a731a68
Fetching gem metadata from https://rubygems.org/............
bundler-audit (0.6.0) has dependency bundler (~> 1.2), which is unsatisfied by the current bundler version 2.1.4, so the dependency is being ignored
…
Done in 266.14s.
```
Note warning: **bundler-audit (0.6.0) has dependency bundler (~> 1.2), which is unsatisfied by the current bundler version 2.1.4, so the dependency is being ignored**

### Solution

1) Revert the bundle version to 1.16.4 (a dependency for the bundler-audit and rails 5.2.1). The bundler version was updated in this PR: https://github.com/powerhome/power-web-development-interview/commit/418f9f2ba8dc1e77ba5b968fd92ea84b7120beb3
2) Set the bundle version explicitly in the Dockerfile for the initial build
3) Set the bundle version explicitly in the docker-compose.yaml for subsequent container restarts

### Testing

1. As a developer run `bin/bootstrap` verify that there are no bundle warnings during the gem installation.
2. As a developer add a new gem to the Gemfile, verify that updating the docker container `bin/bootstrap`, `bin/update`, ... does not throw an exception.
3. As a developer add a new gem to the Gemfile, stop the container (`bin/stop`), start the container (`bin/start`), verify that starting the container does not throw an exception.