### PR TITLE
Allow traffic to pass from host to container

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,7 +16,7 @@ services:
   web:
     tty: true
     build: .
-    command: bash -lc "bin/rails server"
+    command: bash -lc "bin/rails server -b 0.0.0.0"
     links:
       - db
     ports:


### PR DESCRIPTION
The default bind host changed to "localhost" sometime recently. This
allows Puma-in-the-container to respond to traffic passing through the
host's interface - IE make the application available at
`http://localhost:3000`