### PR TITLE
Resolves issue installing Debian dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,14 +10,14 @@ ARG BUILD_TOOLS="\
   gnupg=2.2.12-1+deb10u1 \
   libffi-dev=3.2.1-9 \
   libreadline-dev=7.0-5 \
-  libssl-dev=1.1.1d-0+deb10u7 \
+  libssl-dev=1.1.1n-0+deb10u2 \
   libtool=2.4.6-9 \
-  libxml2-dev=2.9.4+dfsg1-7+deb10u2 \
+  libxml2-dev=2.9.4+dfsg1-7+deb10u4 \
   libyaml-dev=0.2.1-1 \
   make=4.2.1-1.2 \
   unixodbc-dev=2.3.6-0.1 \
   unzip=6.0-23+deb10u2 \
-  zlib1g-dev=1:1.2.11.dfsg-1 \
+  zlib1g-dev=1:1.2.11.dfsg-1+deb10u1 \
   "
 
 RUN apt-get update \


### PR DESCRIPTION
Kudos to @DKRetzlaff for opening https://github.com/powerhome/power-web-development-interview/issues/41 and proposing a fix!

Prior to this commit, bin/bootstrap returned the following error while running `apt-get install`(specifically, the error is related to `libssl-dev` and `libxml2-dev`). 

```
❯ bin/bootstrap
...
Fetched 8487 kB in 1s (5773 kB/s)
Reading package lists...
Reading package lists...
Building dependency tree...
Reading state information...
E: Version '1.1.1d-0+deb10u7' for 'libssl-dev' was not found
E: Version '2.9.4+dfsg1-7+deb10u2' for 'libxml2-dev' was not found
ERROR: Service 'web' failed to build : The command '/bin/sh -c apt-get update   && apt-get install -y $BUILD_TOOLS   && apt-get clean   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*' returned a non-zero code: 100
```

And as @DKRetzlaff [mentioned](https://github.com/powerhome/power-web-development-interview/issues/41#issue-1269852218), zlib1g-dev=1:1.2.11.dfsg-1+deb10u1 has a security fix from [CVE-2018-25032](https://github.com/advisories/GHSA-jc36-42cf-vqwj), which is also patched on this PR.