### PR TITLE
Fix command not found in helper scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
         1.  [OSX](#org5118f49)
         2.  [Debian/Ubuntu Linux](#org7168fc9)
 2.  [Getting Started](#org76343d4)
-3.  [Working with Rails and `docker-compose`](#org23b1de9)
+3.  [Working with Rails and `docker compose`](#org23b1de9)
     1.  [Bootstrapping the application](#org52fd95d)
     2.  [Installing application dependencies](#orge7ed08d)
     3.  [Obtaining a shell](#org422384f)
@@ -55,14 +55,14 @@ Via [homebrew](https://brew.sh/)
 
 <a id="org23b1de9"></a>
 
-# Working with Rails and `docker-compose`
+# Working with Rails and `docker compose`
 
 All of the dependencies to build and run the rails application are
 included in the `web` service's image - named
 `power-web-development-interview_web`. To run typical `bin/rails`
 commands inside the container use the general form:
 
-    docker-compose run --rm web bash -lc "<rails-command>"
+    docker compose run --rm web bash -lc "<rails-command>"
 
 We've provided binstubs for common tasks as a convenience:
 

--- a/bin/bootstrap
+++ b/bin/bootstrap
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 
 bin/cleanup
-docker-compose run --rm web bash -lc "bin/setup"
+docker compose run --rm web bash -lc "bin/setup"

--- a/bin/cleanup
+++ b/bin/cleanup
@@ -1,3 +1,3 @@
 #!/usr/bin/env sh
 
-docker-compose down --rmi=all --volumes
+docker compose down --rmi=all --volumes

--- a/bin/console
+++ b/bin/console
@@ -1,3 +1,3 @@
 #!/usr/bin/env sh
 
-docker-compose run --rm web bash -lc "bin/rails console"
+docker compose run --rm web bash -lc "bin/rails console"

--- a/bin/deps
+++ b/bin/deps
@@ -1,3 +1,3 @@
 #!/usr/bin/env sh
 
-docker-compose run --rm web bash -lc "(bin/bundle check || bin/bundle install) && (bin/yarn check || bin/yarn install)"
+docker compose run --rm web bash -lc "(bin/bundle check || bin/bundle install) && (bin/yarn check || bin/yarn install)"

--- a/bin/shell
+++ b/bin/shell
@@ -1,3 +1,3 @@
 #!/usr/bin/env sh
 
-docker-compose run --rm web bash -l
+docker compose run --rm web bash -l

--- a/bin/start
+++ b/bin/start
@@ -1,3 +1,3 @@
 #!/usr/bin/env sh
 
-docker-compose up web
+docker compose up web

--- a/bin/stop
+++ b/bin/stop
@@ -1,3 +1,3 @@
 #!/usr/bin/env sh
 
-docker-compose stop
+docker compose stop


### PR DESCRIPTION
The functionally previously provided by docker-compose has been baked into the docker CLI and docker-compose is no longer shipped with the Docker for Desktop application bundle.

When running this project's helper scripts on recent version of docker / Docker for Desktop the docker-compose command is not found:

```
$ bin/bootstrap
bin/cleanup: line 3: docker-compose: command not found
bin/bootstrap: line 4: docker-compose: command not found
```