### PR TITLE
Add dependencies label to Renovate PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
   "extends": [
     "config:base"
-  ]
+  ],
+  "labels": ["dependencies"]
 }


### PR DESCRIPTION
With the new [Stalebot config](https://github.com/powerhome/power-web-development-interview/blob/main/.github/workflows/stale.yml), PRs that go "stale" (not having pushes or interactions for 4+ days) are automatically closed. There is a rule in the config that creates an exception for PRs with the "dependencies" label, and this change will make Renovate automatically add this label to its PRs so they don't get pruned for being stale.