### PR TITLE
Build fix and Gemfile.lock update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,12 +49,8 @@ RUN asdf plugin add ruby \
   && asdf plugin add yarn
 
 COPY --chown=app .tool-versions /home/app/
-# REMOVE ME: Workaround for https://bugs.ruby-lang.org/issues/20085.
-# The RUBY_APPLY_PATCHES var should be removed either when ruby is
-# upgraded to a version >3.3.0 or a newer version of ruby-build is
-# available to asdf-ruby which includes the backported patch to ruby
-# 3.3.0.
-RUN RUBY_APPLY_PATCHES="https://patch-diff.githubusercontent.com/raw/ruby/ruby/pull/9371.diff" asdf install
+
+RUN asdf install
 
 ENV BUNDLER_VERSION=2.4.10
 RUN gem install bundler --version $BUNDLER_VERSION

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -347,7 +347,7 @@ DEPENDENCIES
   pry-byebug
   pry-rails
   puma (= 6.6.0)
-  rails (~> 8.0.1)
+  rails (= 8.0.2)
   rspec-rails (= 8.0.0)
   sass-rails (= 6.0.0)
   shoulda-matchers

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 
 Via [homebrew](https://brew.sh/)
 
-    brew cask install docker
+    brew install --cask docker
 
 
 <a id="org7168fc9"></a>


### PR DESCRIPTION
# Overview
This PR aims to fix a build issue installing ruby 3.4.4 that I noticed while trying to run `bin/bootstrap` for the first time. It also includes an update to the Gemfile.lock to set the Rails version to 8.0.2, and an update to docker install instructions with homebrew.

## The error
```
 => ERROR [ 9/13] RUN RUBY_APPLY_PATCHES="https://patch-diff.githubusercontent.com/raw/ruby/ruby/pull/9371.diff" asdf install                    7.1s
------
 > [ 9/13] RUN RUBY_APPLY_PATCHES="https://patch-diff.githubusercontent.com/raw/ruby/ruby/pull/9371.diff" asdf install:
0.115 Cloning node-build...
0.981 To follow progress, use 'tail -f /tmp/node-build.20250719125859.113.log' or pass --verbose
0.991 Downloading node-v22.17.0-linux-arm64.tar.gz...
1.182 -> https://nodejs.org/dist/v22.17.0/node-v22.17.0-linux-arm64.tar.gz
4.176 Installing node-v22.17.0-linux-arm64...
4.315 Installed node-v22.17.0-linux-arm64 to /home/app/.asdf/installs/nodejs/22.17.0
4.315
4.429 Downloading ruby-build...
4.994 Using patch from URL: https://patch-diff.githubusercontent.com/raw/ruby/ruby/pull/9371.diff
5.305 ==> Downloading ruby-3.4.4.tar.gz...
5.306 -> curl -q -fL -o ruby-3.4.4.tar.gz https://cache.ruby-lang.org/pub/ruby/3.4/ruby-3.4.4.tar.gz
5.310   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
5.310                                  Dload  Upload   Total   Spent    Left  Speed
100 22.1M  100 22.1M    0     0  25.5M      0 --:--:-- --:--:-- --:--:-- 25.5M
6.874 ==> Installing ruby-3.4.4...
6.876 -> patch -p1 --force -i /tmp/ruby-patch.Ip0c9o
6.876 patching file configure.ac
6.876 Hunk #1 FAILED at 830.
6.877 1 out of 1 hunk FAILED -- saving rejects to file configure.ac.rej
6.877
6.877 BUILD FAILED (Debian GNU/Linux 12 on aarch64 using ruby-build 20250610)
6.879
6.880 You can inspect the build directory at /tmp/ruby-build.20250719125903.479.4nc9KW
6.881 See the full build log at /tmp/ruby-build.20250719125903.479.log
------
Dockerfile:57

--------------------

  55 |     # available to asdf-ruby which includes the backported patch to ruby

  56 |     # 3.3.0.

  57 | >>> RUN RUBY_APPLY_PATCHES="https://patch-diff.githubusercontent.com/raw/ruby/ruby/pull/9371.diff" asdf install

  58 |

  59 |     ENV BUNDLER_VERSION=2.4.10

--------------------

failed to solve: process "/bin/bash -l -c RUBY_APPLY_PATCHES=\"https://patch-diff.githubusercontent.com/raw/ruby/ruby/pull/9371.diff\" asdf install" did not complete successfully: exit code: 1



View build details: docker-desktop://dashboard/build/desktop-linux/desktop-linux/dduo7e4ahmsc2ye7axks50674
```

## The fix
I saw this comment in the Dockerfile (starting at line 52):
```
# REMOVE ME: Workaround for https://bugs.ruby-lang.org/issues/20085.
# The RUBY_APPLY_PATCHES var should be removed either when ruby is
# upgraded to a version >3.3.0 or a newer version of ruby-build is
# available to asdf-ruby which includes the backported patch to ruby
# 3.3.0.
RUN RUBY_APPLY_PATCHES="https://patch-diff.githubusercontent.com/raw/ruby/ruby/pull/9371.diff" asdf install
```
Given that my build logs indicated it was trying to install ruby 3.4.4 (and also given that that's the ruby version defined in `.tool-versions`) I decided to try removing the patches, and was able to proceed past the error. 