### PR TITLE
Update Deprecated fixture_path config

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -17,7 +17,7 @@ end
 module SystemTestSupport; end
 
 RSpec.configure do |config|
-  config.fixture_path = "#{::Rails.root}/spec/fixtures"
+  config.fixture_paths = [Rails.root.join("spec/fixtures")]
   config.use_transactional_fixtures = true
   config.infer_spec_type_from_file_location!
   config.filter_rails_from_backtrace!


### PR DESCRIPTION
`fixture_path` was [deprecated in Rails 7.1](https://rubyonrails.org/2023/3/18/this-week-in-rails-testfixtures-fixture_path-deprecation-findermethods-find-support-for-composite-primary-key-values-87e6e69a) and then removed in Rails 7.2. Ex:

```
An error occurred while loading ./spec/models/post_spec.rb.
Failure/Error: config.fixture_path = "#{::Rails.root}/spec/fixtures"

NoMethodError:
  undefined method 'fixture_path=' for #<RSpec::Core::Configuration:0x0000ffff72e90c88>
```

This PR updates the `rails_helper.rb` fixture_paths config and changes the singular configuration to an array syntax.

<img width="493" height="184" alt="Screenshot 2026-06-27 at 2 02 38 PM" src="https://github.com/user-attachments/assets/00a01808-8f1d-47a2-b03b-d7bcf1bf9d52" />
